### PR TITLE
solves #1

### DIFF
--- a/conf/lsf.config
+++ b/conf/lsf.config
@@ -1,0 +1,11 @@
+// LSF specific config
+executor {
+    name = 'lsf'
+    perJobMemLimit = true
+    queueSize = 500
+}
+
+process {
+    pollInterval = '30 sec'
+    memory = '4 GB'
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,6 +50,10 @@ profiles {
     process.executor = 'slurm'
     includeConfig 'conf/slurm.config'
   }
+  lsf {
+    process.executor = 'lsf'
+    includeConfig 'conf/lsf.config'
+  }
 }
 
 // Capture exit codes from upstream processes when piping


### PR DESCRIPTION
I've added the Sanger-specific configurations in a separate file (`conf/sanger.lsf`) that contains queue and group info and can be added from command-line (`-c conf/sanger.lsf`):
```
> cat conf/sanger.lsf
process {
    clusterOptions = { "-R 'avx512' -G malaria-dk" }
    queue = 'heron'
}
```