### PR TITLE
Issue3 cramtofastq

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -7,6 +7,7 @@ nextflow.preview.dsl = 2
 include {articNcovNanopolish} from './workflows/articNcovNanopolish.nf' params(params)
 include {articNcovMedaka} from './workflows/articNcovMedaka.nf' params(params)
 include {ncovIllumina} from './workflows/illuminaNcov.nf' params(params)
+include {ncovIlluminaCram} from './workflows/illuminaNcov.nf' params(params)
 
 // main workflow
 workflow {

--- a/main.nf
+++ b/main.nf
@@ -13,9 +13,14 @@ workflow {
   
    runDirectory = "${params.directory}"
    if ( params.illumina ) {
-  
-       Channel.fromFilePairs( params.fastqSearchPath, flat: true)
-              .set{ ch_filePairs }
+       if (params.cram) {
+        Channel.fromPath( "${runDirectory}*.cram" )
+              .set{ ch_cramDirectory }
+       }
+       else {
+	   Channel.fromFilePairs( params.fastqSearchPath, flat: true)
+			  .set{ ch_filePairs }
+	   }
    }
    else {
        Channel.fromPath( "${runDirectory}" )
@@ -28,7 +33,12 @@ workflow {
      } else if ( params.nanopolish ) {
          articNcovNanopolish(ch_runDirectory)
      } else if ( params.illumina ) {
-         ncovIllumina(ch_filePairs)
+         if(params.cram) {
+            ncovIlluminaCram(ch_cramDirectory)
+         }
+         else {
+            ncovIllumina(ch_filePairs)
+         }
      } else {
          println("Please select a workflow with --nanopolish, --illumina or --medaka")
      }

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -152,7 +152,7 @@ process cramToFastq {
         file(cram)
 
     output:
-        tuple(val(${cram.toString().replaceFirst(/\.cram/, "")}), path("*_1.fastq.gz"),path("*_2.fastq.gz"))
+        tuple(val("${cram.toString().replaceFirst(/\.cram/, "")}"), path("*_1.fastq.gz"),path("*_2.fastq.gz"))
 
     script:
         """

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -157,7 +157,7 @@ process cramToFastq {
     script:
         """
         samtools collate -u ${cram} -o tmp.bam
-        samtools fastq -1 ${cram.toString().replaceFirst(/\.cram/, "_1.fastq.gz")} -2 ${cram.toString().replaceFirst(/\.cram/, "_2.fastq.gz")}
+        samtools fastq -1 ${cram.toString().replaceFirst(/\.cram/, "_1.fastq.gz")} -2 ${cram.toString().replaceFirst(/\.cram/, "_2.fastq.gz")} tmp.bam
         rm tmp.bam
         """
 }

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -138,3 +138,27 @@ process makeConsensus {
         """
 }
 
+process cramToFastq {
+    /**
+    * Converts CRAM to fastq (http://bio-bwa.sourceforge.net/)
+    * Uses samtools to convert to CRAM, to FastQ (http://www.htslib.org/doc/samtools.html)
+    * @input
+    * @output
+    */
+
+    //publishDir "${params.outdir}/${task.process.replaceAll(":","_")}"
+
+    input:
+        file(cram)
+
+    output:
+        tuple(val(${cram.toString().replaceFirst(/\.cram/, "")}), path("*_1.fastq.gz"),path("*_2.fastq.gz"))
+
+    script:
+        """
+        samtools collate -u ${cram} -o tmp.bam
+        samtools fastq -1 ${cram.toString().replaceFirst(/\.cram/, "_1.fastq.gz")} -2 ${cram.toString().replaceFirst(/\.cram/, "_2.fastq.gz")} tmp.$
+        rm tmp.bam
+        """
+}
+

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -157,7 +157,7 @@ process cramToFastq {
     script:
         """
         samtools collate -u ${cram} -o tmp.bam
-        samtools fastq -1 ${cram.toString().replaceFirst(/\.cram/, "_1.fastq.gz")} -2 ${cram.toString().replaceFirst(/\.cram/, "_2.fastq.gz")} tmp.$
+        samtools fastq -1 ${cram.toString().replaceFirst(/\.cram/, "_1.fastq.gz")} -2 ${cram.toString().replaceFirst(/\.cram/, "_2.fastq.gz")}
         rm tmp.bam
         """
 }

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -64,3 +64,11 @@ workflow ncovIllumina {
       }
 }
 
+workflow ncovIlluminaCram {
+    take:
+      ch_cramDirectory
+    main:
+      cramToFastq(ch_cramDirectory)
+      ncovIllumina(cramToFastq.out)
+}
+

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -14,6 +14,8 @@ include {makeConsensus} from '../modules/illumina.nf' params(params)
 include {collateSamples} from '../modules/upload.nf' params(params)
 include {uploadToCLIMB} from '../modules/upload.nf' params(params)
 
+include {cramToFastq} from '../modules/illumina.nf' params(params)
+
 workflow sequenceAnalysis {
     take:
       ch_filePairs


### PR DESCRIPTION
Added `--cram` option to switch input from a directory of fastq to a directory for cram.

Currently only applies to the `--illumina` branch

Example usage:

```bash
bash ~/nextflow run ./ncov2019-artic-nf -profile lsf,singularity --illumina --directory ./cram/ --cram
```