### PR TITLE
Resolved issue #9 - corrected --cram option requiring trailing slash

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -15,7 +15,7 @@ workflow {
    runDirectory = "${params.directory}"
    if ( params.illumina ) {
        if (params.cram) {
-        Channel.fromPath( "${runDirectory}*.cram" )
+        Channel.fromPath( "${runDirectory}/*.cram" )
               .set{ ch_cramDirectory }
        }
        else {


### PR DESCRIPTION
Changed `Channel.fromPath( "${runDirectory}*.cram" )` to `Channel.fromPath( "${runDirectory}/*.cram" )`

Tested `--directory` with both `./cram/` and `./cram`. Both versions detected the correct number of crams