### PR TITLE
Remove unnecessary samtools view -bS

### DIFF
--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -69,7 +69,7 @@ process readMapping {
 
     script:
         """
-        bwa mem -t ${task.cpus} ${ref} ${forward} ${reverse} | samtools view -bS | \
+        bwa mem -t ${task.cpus} ${ref} ${forward} ${reverse} | \
         samtools sort -o ${sampleName}.sorted.bam
         """
 }


### PR DESCRIPTION
Samtools sort has been able to read more than BAM for a long time, hence "samtools view -bS | samtools sort ..." is just an unnecessary CPU consuming command.

I tested both the outputs (with and without 'samtools view -bS') and md5sum is the same for both. 